### PR TITLE
Improve matching of ld+json name keys and urls

### DIFF
--- a/technology-rules/translations/ld-json.json
+++ b/technology-rules/translations/ld-json.json
@@ -1,4 +1,4 @@
-{
+{ 
   "$schema": "../schemas/translations.schema.json",
   "title": "application/ld+json",
   "translations": [
@@ -24,6 +24,8 @@
         {
           "paths": [
             "$.name",
+            "$[*]['name']",
+            "$.itemListElement[*].item.name",
             "$.description",
             "$.headline",
             "$.offers[*].itemOffered.name"
@@ -31,7 +33,7 @@
           "wordType": 1
         },
         {
-          "paths": ["$.url", "$.offers[*].url", "$.offers[*].itemOffered.url"],
+          "paths": ["$.url", "$[*]['url']", "$.offers[*].url", "$.itemListElement[*].item['@id']", "$.offers[*].itemOffered.url"],
           "type": "URL",
           "forceURLFormat": "siteSettings"
         }


### PR DESCRIPTION
Closes Connect issue #291 (https://github.com/weglot/connect-edge/issues/291)

@roptch, @remyberda  : les clés 'name' et 'url' étaient déjà gérés par les definitions de `ld+json`, mais pour ce site les jsonPaths étaient un peu différents parce que les clés étaient dans des lists nestés. J'ai ajouté les paths pour gérer ce cas spécifique -- mais est-ce que c'est assez général ou il y a d'autres cas à part celui-là qu'il faut gérer aussi ?