### PR TITLE
Add Shopify product script regexes by default

### DIFF
--- a/technology-rules/translations/shopify.json
+++ b/technology-rules/translations/shopify.json
@@ -191,6 +191,10 @@
         {
           "selector": "script",
           "regex": "Shopify.routes.root = \"(?<url>[^\"]+)\""
+        },
+        {
+          "selector": "script",
+          "regex": "(?:addToCart|soldOut|lowStock|quantityLabel|product_page_text|onSale|unavailable|added|viewProduct|percentOff|description|title|text): \"(?<wordType1>[^\"]+)"
         }
       ]
     }

--- a/technology-rules/translations/shopify.json
+++ b/technology-rules/translations/shopify.json
@@ -194,7 +194,23 @@
         },
         {
           "selector": "script",
-          "regex": "(?:addToCart|soldOut|lowStock|quantityLabel|product_page_text|onSale|unavailable|added|viewProduct|percentOff|description|title|text): \"(?<wordType1>[^\"]+)"
+          "regex": "strings(?:[: =]*)(?<json>[^}]+\\})(?:,|;|\n])",
+          "id": "shopify-strings"
+        }
+      ]
+    },
+    {
+      "type": "JSON",
+      "condition": [
+        {
+          "type": "FROM_DEFINITION_ID",
+          "payload": "shopify-strings"
+        }	
+      ],
+      "value": [
+        {
+          "paths": ["addToCart","soldOut","lowStock","quantityLabel","product_page_text","onSale","unavailable","added","viewProduct","percentOff","description","title","text"],
+          "wordType": 1
         }
       ]
     }


### PR DESCRIPTION
Je ne sais pas si vous voyez une meilleure façon de gérer ça de manière plus optimale.

Pour choisir les mots clés à cibler j'ai juste regardé la liste de custom_settings existants et choisi ceux qui apparaissaient dans plusieurs. Après il y aura sûrement d'autres, soit selon la thème soit selon si le client choisit d'exposer à l'utilisateur certains boutons / textes etc.

J'avais essayé d'abord de plutôt cibler l'objet JSON `strings` via un seul regex, comme ça on pourrait ne faire qu'un regexcheck dans chaque balise `script` et en suite parser le JSON en ciblant des clés, ce qui a priori me semble plus efficace que de mettre plein d'alternatifs dans le regex. Mais les JSONs n'étaient pas du tout dans un format standard, e.g., il y a des valeurs contenant des variables comme `{{ variable_name }}`, de l'HTML encodé dans les valeurs, en fin des cas qui pourraient casser le match JSON. ça devrait quand-même être possible si on essayait de mieux choisir le regex, mais je me demandais si finalement ça ne finirait pas comme un regex aussi complexe que celui que j'ai fait avec des mots clés. Vous me dites si vous pensez qu'il faudrait essayer comme ça. 