### PR TITLE
Only translate Shopify routes root on subdirectory

### DIFF
--- a/technology-rules/translations/shopify.json
+++ b/technology-rules/translations/shopify.json
@@ -194,10 +194,6 @@
         },
         {
           "selector": "script",
-          "regex": "Shopify.routes.root = \"(?<url>[^\"]+)\""
-        },
-        {
-          "selector": "script",
           "regex": "strings(?:[: =]*)(?<json>[^}]+\\})(?:,|;|\n])",
           "id": "shopify-strings"
         },
@@ -205,6 +201,25 @@
           "selector": "button",
           "attribute": "data-add-to-cart-text",
           "wordType": 1
+        }
+      ]
+    },
+    {
+      "type": "HTML",
+      "condition": [
+        {
+          "type": "TECHNOLOGY_ID",
+          "payload": 2
+        },
+        {
+          "type": "URL_TYPE",
+          "payload": "subdirectory"
+        }
+      ],
+      "value": [
+        {
+          "selector": "script",
+          "regex": "Shopify.routes.root = \"(?<url>[^\"]+)\""
         }
       ]
     },


### PR DESCRIPTION
See the associated PR in Connect Edge, (https://github.com/weglot/connect-edge/pull/461/files)

This just reduces by 1 the number of Regex checks per Shopify (page x script), for subdomain sites. The routes.root property is only important where we modify/add a locale to the path.