### PR TITLE
Translate URL for Shopify thankyou page on new checkout

### DIFF
--- a/technology-rules/package.json
+++ b/technology-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weglot/technology-rules",
-  "version": "3.24.0",
+  "version": "3.24.1",
   "main": "index.js",
   "repository": "git@github.com:weglot/technology-rules.git",
   "author": "Weglot <support@weglot.com>",

--- a/technology-rules/translations/shopify.json
+++ b/technology-rules/translations/shopify.json
@@ -35,6 +35,30 @@
           "type": "PATH_MATCH",
           "payload": {
             "type": "MATCH_REGEX",
+            "value": "^\\/checkouts\\/(unstable|[\\d-]+)\\/graphql"
+          }
+        }
+      ],
+      "value": [
+        {
+          "paths": [
+            "$..classicThankYouPageUrl"
+          ],
+          "type": "URL"
+        }
+      ]
+    },
+    {
+      "type": "JSON",
+      "condition": [
+        {
+          "type": "TECHNOLOGY_ID",
+          "payload": 2
+        },
+        {
+          "type": "PATH_MATCH",
+          "payload": {
+            "type": "MATCH_REGEX",
             "value": "\\/products\\.json$"
           }
         }


### PR DESCRIPTION
To stop the 404 error on the new Shopify checkout (https://github.com/weglot/connect-edge/issues/547) 