### PR TITLE
Add conditional schemas according to resource type

### DIFF
--- a/technology-rules/package.json
+++ b/technology-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weglot/technology-rules",
-  "version": "3.24.2",
+  "version": "3.24.3",
   "main": "index.js",
   "repository": "git@github.com:weglot/technology-rules.git",
   "author": "Weglot <support@weglot.com>",

--- a/technology-rules/schemas/common.schema.json
+++ b/technology-rules/schemas/common.schema.json
@@ -18,7 +18,7 @@
     },
     "Type": {
       "title": "Resource type",
-      "description": "What kind of page(s) do you want the rule to apply to?",
+      "description": "What kind of page(s) or resource(s) do you want the rule to apply to?",
       "type": "string",
       "default": "HTML",
       "oneOf": [
@@ -44,21 +44,66 @@
       "description": "A Weglot Technology ID",
       "type": "integer",
       "oneOf": [
-        { "const": 1, "title": "1 (WordPress)" },
-        { "const": 2, "title": "2 (Shopify)" },
-        { "const": 3, "title": "3 (BigCommerce)" },
-        { "const": 4, "title": "4 (Jimdo)" },
-        { "const": 5, "title": "5 (Squarespace)" },
-        { "const": 6, "title": "6 (Wix)" },
-        { "const": 7, "title": "7 (Laravel)" },
-        { "const": 8, "title": "8 (Symfony)" },
-        { "const": 9, "title": "9 (Weebly)" },
-        { "const": 10, "title": "10 (Drupal)" },
-        { "const": 11, "title": "11 (OctoberCMS)" },
-        { "const": 12, "title": "12 (Other)" },
-        { "const": 13, "title": "13 (Webflow)" },
-        { "const": 14, "title": "14 (Prestashop)" },
-        { "const": 15, "title": "15 (Magento)" }
+        {
+          "const": 1,
+          "title": "1 (WordPress)"
+        },
+        {
+          "const": 2,
+          "title": "2 (Shopify)"
+        },
+        {
+          "const": 3,
+          "title": "3 (BigCommerce)"
+        },
+        {
+          "const": 4,
+          "title": "4 (Jimdo)"
+        },
+        {
+          "const": 5,
+          "title": "5 (Squarespace)"
+        },
+        {
+          "const": 6,
+          "title": "6 (Wix)"
+        },
+        {
+          "const": 7,
+          "title": "7 (Laravel)"
+        },
+        {
+          "const": 8,
+          "title": "8 (Symfony)"
+        },
+        {
+          "const": 9,
+          "title": "9 (Weebly)"
+        },
+        {
+          "const": 10,
+          "title": "10 (Drupal)"
+        },
+        {
+          "const": 11,
+          "title": "11 (OctoberCMS)"
+        },
+        {
+          "const": 12,
+          "title": "12 (Other)"
+        },
+        {
+          "const": 13,
+          "title": "13 (Webflow)"
+        },
+        {
+          "const": 14,
+          "title": "14 (Prestashop)"
+        },
+        {
+          "const": 15,
+          "title": "15 (Magento)"
+        }
       ]
     },
     "BodyReplacement": {
@@ -71,7 +116,10 @@
         "slash": {
           "type": "string",
           "default": "/",
-          "enum": ["/", "\\/"],
+          "enum": [
+            "/",
+            "\\/"
+          ],
           "description": "The slash character in that context. Sometimes, the slash character needs to be escaped"
         }
       }

--- a/technology-rules/schemas/condition.schema.json
+++ b/technology-rules/schemas/condition.schema.json
@@ -4,11 +4,20 @@
   "definitions": {
     "ConditionArray": {
       "title": "Conditions",
-      "description": "Conditions to be satisfied before the rule is applied",
+      "description": "These are the conditions that must be satisfied before your custom translation rule is applied.",
       "type": "array",
       "default": [],
       "items": {
         "$ref": "#/definitions/Condition"
+      }
+    },
+    "ConditionArrayXml": {
+      "title": "Conditions",
+      "description": "These are the conditions that must be satisfied before your custom translation rule is applied.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "$ref": "#/definitions/ConditionXml"
       }
     },
     "Condition": {
@@ -19,35 +28,27 @@
         "type": {
           "title": "Condition type",
           "type": "string",
-          "default": "FROM_DEFINITION_ID",
+          "description": "What kind of condition do you want to match for?",
           "oneOf": [
             {
               "const": "FROM_DEFINITION_ID",
-              "title": "Comes from a specific parent definition"
+              "title": "Match the defintion that created this resource"
             },
             {
               "const": "PATH_MATCH",
-              "title": "URL path match"
+              "title": "Match the URL path"
             },
             {
               "const": "URI_MATCH",
-              "title": "Original URL match"
+              "title": "Match the whole original URL"
             },
             {
               "const": "TECHNOLOGY_ID",
-              "title": "Website CMS technology"
+              "title": "Match the technology of the website CMS"
             },
             {
               "const": "HEADERS_SIGNATURE",
-              "title": "Match incoming headers"
-            },
-            {
-              "const": "XML_ATTRIBUTE_VALUE",
-              "title": "Check an XML attribute value on XML resources"
-            },
-            {
-              "const": "XML_ROOT_ELEMENT_NAME",
-              "title": "Check if XML element is present and at document's root"
+              "title": "Check the incoming website headers"
             },
             {
               "const": "URL_TYPE",
@@ -55,9 +56,9 @@
             }
           ]
         },
-      "payload": {
-        "title": ""
-      }
+        "payload": {
+          "title": ""
+        }
       },
       "dependencies": {
         "type": {
@@ -79,7 +80,7 @@
                   "const": "URI_MATCH"
                 },
                 "payload": {
-                  "description": "The URL of the resource we want to translate (without query string) needs to be in the list",
+                  "description": "Match the full URL of the resource we want to translate (without query string)",
                   "$ref": "#/definitions/PathMatch"
                 }
               }
@@ -90,7 +91,134 @@
                   "const": "PATH_MATCH"
                 },
                 "payload": {
-                  "description": "The path of the resource we want to translate needs to fulfill a criteria",
+                  "description": "Match the path of the resource we want to translate",
+                  "$ref": "#/definitions/PathMatch"
+                }
+              }
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "TECHNOLOGY_ID"
+                },
+                "payload": {
+                  "description": "Only applies for pages served by the selected technology",
+                  "$ref": "common.schema.json#/definitions/TechnologyID"
+                }
+              }
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "HEADERS_SIGNATURE"
+                },
+                "payload": {
+                  "description": "Detect using the incoming headers from the source",
+                  "$ref": "#/definitions/HeadersSignature"
+                }
+              }
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "URL_TYPE"
+                },
+                "payload": {
+                  "type": "string",
+                  "enum": [
+                    "subdirectory",
+                    "subdomain"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "required": [
+        "payload",
+        "type"
+      ]
+    },
+    "ConditionXml": {
+      "description": "",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "title": "Condition type",
+          "type": "string",
+          "oneOf": [
+            {
+              "const": "FROM_DEFINITION_ID",
+              "title": "Match the defintion that created this resource"
+            },
+            {
+              "const": "PATH_MATCH",
+              "title": "Match the URL path"
+            },
+            {
+              "const": "URI_MATCH",
+              "title": "Match the entire original URL"
+            },
+            {
+              "const": "TECHNOLOGY_ID",
+              "title": "Match the technology of the website CMS"
+            },
+            {
+              "const": "HEADERS_SIGNATURE",
+              "title": "Check the incoming website headers"
+            },
+            {
+              "const": "XML_ATTRIBUTE_VALUE",
+              "title": "Match the value of an XML tag attribute"
+            },
+            {
+              "const": "XML_ROOT_ELEMENT_NAME",
+              "title": "Test if an XML element is present and at the document root"
+            },
+            {
+              "const": "URL_TYPE",
+              "title": "Check if the site is using subdirectory or subdomain"
+            }
+          ]
+        },
+        "payload": {
+          "title": ""
+        }
+      },
+      "dependencies": {
+        "type": {
+          "oneOf": [
+            {
+              "properties": {
+                "type": {
+                  "const": "FROM_DEFINITION_ID"
+                },
+                "payload": {
+                  "type": "string",
+                  "title": "ID of the parent definition"
+                }
+              }
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "URI_MATCH"
+                },
+                "payload": {
+                  "description": "Match the full URL of the resource we want to translate (without query string)",
+                  "$ref": "#/definitions/PathMatch"
+                }
+              }
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "PATH_MATCH"
+                },
+                "payload": {
+                  "description": "Match the path of the resource we want to translate",
                   "$ref": "#/definitions/PathMatch"
                 }
               }
@@ -123,16 +251,20 @@
                   "const": "XML_ATTRIBUTE_VALUE"
                 },
                 "payload": {
+                  "additionalProperties": false,
                   "type": "object",
                   "properties": {
                     "selector": {
+                      "title": "CSS selector",
                       "type": "string"
                     },
                     "attr": {
+                      "title": "Attribute name",
                       "type": "string"
                     },
                     "value": {
-                      "type": "string"
+                      "type": "string",
+                      "title": "Attribute value"
                     }
                   }
                 }
@@ -160,39 +292,61 @@
                 },
                 "payload": {
                   "type": "string",
-                  "enum": ["subdirectory", "subdomain"]
+                  "enum": [
+                    "subdirectory",
+                    "subdomain"
+                  ]
                 }
               }
             }
           ]
         }
       },
-      "required": ["payload", "type"]
+      "required": [
+        "payload",
+        "type"
+      ]
     },
     "PathMatch": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "type": {
-          "title": "Path Match mode",
+          "title": "What check do you want to apply to the path?",
           "type": "string",
-          "default": "START_WITH",
-          "enum": [
-            "START_WITH",
-            "END_WITH",
-            "CONTAIN",
-            "IS_EXACTLY",
-            "MATCH_REGEX"
-          ],
-          "description": "Refer to https://app.gitbook.com/@weglot/s/weglot-ninjas/core/api-reference for the meaning of each option"
+          "oneOf": [
+            {
+              "const": "START_WITH",
+              "title": "The URL starts with..."
+            },
+            {
+              "const": "END_WITH",
+              "title": "The URL ends with..."
+            },
+            {
+              "const": "CONTAIN",
+              "title": "The URL contains..."
+            },
+            {
+              "const": "IS_EXACTLY",
+              "title": "The URL is exactly..."
+            },
+            {
+              "const": "MATCH_REGEX",
+              "title": "The URL matches the regex pattern..."
+            }
+          ]
         },
         "value": {
-          "title": "Value",
-          "type": "string",
-          "description": "E.g: /blog"
+          "title": "Matching string value",
+          "description": "The value you want to apply the test above for, e.g., /blog.",
+          "type": "string"
         }
       },
-      "required": ["type", "value"],
+      "required": [
+        "type",
+        "value"
+      ],
       "title": "Path Match"
     },
     "HeadersSignature": {
@@ -209,7 +363,9 @@
           "description": "If provided, the header value should match this RegExp string. Leave empty to only check for presence"
         }
       },
-      "required": ["headerName"]
+      "required": [
+        "headerName"
+      ]
     }
   }
 }

--- a/technology-rules/schemas/translations.schema.json
+++ b/technology-rules/schemas/translations.schema.json
@@ -16,74 +16,230 @@
         "properties": {
           "type": {
             "$ref": "common.schema.json#/definitions/Type"
-          },
-          "condition": {
-            "$ref": "condition.schema.json#/definitions/ConditionArray"
-          },
-          "value": {
-            "$ref": "#/definitions/ValueArray"
           }
         },
-        "required": ["type", "value"]
+        "dependencies": {
+          "type": {
+            "oneOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "HTML"
+                  },
+                  "condition": {
+                    "$ref": "condition.schema.json#/definitions/ConditionArray"
+                  },
+                  "value": {
+                    "$ref": "#/definitions/ValueArrayHtml"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "JSON"
+                  },
+                  "condition": {
+                    "$ref": "condition.schema.json#/definitions/ConditionArray"
+                  },
+                  "value": {
+                    "$ref": "#/definitions/ValueArrayJson"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "XML"
+                  },
+                  "condition": {
+                    "$ref": "condition.schema.json#/definitions/ConditionArrayXml"
+                  },
+                  "value": {
+                    "$ref": "#/definitions/ValueArrayXml"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "RAW"
+                  },
+                  "condition": {
+                    "$ref": "condition.schema.json#/definitions/ConditionArray"
+                  },
+                  "value": {
+                    "$ref": "#/definitions/ValueArrayRaw"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
       }
     }
   },
-  "required": ["$schema", "title", "translations"],
+  "required": [
+    "$schema",
+    "title",
+    "translations"
+  ],
   "definitions": {
-    "ValueArray": {
-      "title": "If condition was true, apply these definitions",
+    "ValueArrayHtml": {
+      "title": "Translation options",
       "type": "array",
-      "description": "Put here definitions to translate",
+      "description": "Select the options for translating your page. They will be applied on all HTML pages matching the conditions above.",
       "items": {
-        "$ref": "#/definitions/Value"
+        "$ref": "#/definitions/ValueHtml"
       }
     },
-    "Value": {
+    "ValueArrayRaw": {
+      "title": "Translation options",
+      "type": "array",
+      "description": "Select the options for translating your page. They will be applied on all RAW files matching the conditions above.",
+      "items": {
+        "$ref": "#/definitions/ValueRaw"
+      }
+    },
+    "ValueArrayJson": {
+      "title": "Translation options",
+      "type": "array",
+      "description": "Select the options for translating your page. They will be applied on all JSON files matching the conditions above.",
+      "items": {
+        "$ref": "#/definitions/ValueJson"
+      }
+    },
+    "ValueArrayXml": {
+      "title": "Translation options",
+      "type": "array",
+      "description": "Select the options for translating your page. They will be applied on all XML files matching the conditions above.",
+      "items": {
+        "$ref": "#/definitions/ValueXml"
+      }
+    },
+    "ValueHtml": {
       "title": "",
       "description": "",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "id": {
-          "title": "Identify this definition to refer it later",
-          "type": "string"
+          "$ref": "#/definitions/DefinitionID"
         },
         "selector": {
-          "title": "CSS selector",
-          "type": "string"
+          "$ref": "#/definitions/DefinitionSelector"
         },
         "attribute": {
-          "title": "HTML attribute to translate",
-          "type": "string"
+          "$ref": "#/definitions/DefinitionHtmlAttribute"
         },
         "regex": {
-          "title": "A regular expression",
-          "type": "string"
-        },
-        "paths": {
-          "title": "",
-          "description": "List of JSONPath strings that match this word type",
-          "$ref": "#/definitions/JSONPathArray"
+          "$ref": "#/definitions/DefinitionRegex"
         },
         "wordType": {
-          "title": "Word Type",
-          "description": "",
-          "$ref": "#/definitions/WordType"
+          "$ref": "#/definitions/DefinitionWordType"
         },
         "type": {
-          "title": "Target type",
-          "description": "Parse found matches with this type",
-          "$ref": "#/definitions/TargetType"
-        },
-        "forceURLFormat": {
-          "title": "URL format to force",
-          "description": "Parse URL with this format",
-          "$ref": "#/definitions/ForceURLFormat"
+          "$ref": "#/definitions/DefinitionTargetType"
+        }
+      },
+      "dependencies": {
+        "type": {
+          "$ref": "#/definitions/DefinitionDependencyType"
         }
       }
     },
-    "JSONPathArray": {
-      "description": "List of JSONPath strings",
+    "ValueJson": {
+      "title": "",
+      "description": "",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/DefinitionID"
+        },
+        "paths": {
+          "$ref": "#/definitions/DefinitionJSONPathArray"
+        },
+        "wordType": {
+          "$ref": "#/definitions/DefinitionWordType"
+        },
+        "type": {
+          "$ref": "#/definitions/DefinitionTargetType"
+        }
+      },
+      "dependencies": {
+        "type": {
+          "$ref": "#/definitions/DefinitionDependencyType"
+        }
+      }
+    },
+    "ValueXml": {
+      "title": "",
+      "description": "",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/DefinitionID"
+        },
+        "paths": {
+          "$ref": "#/definitions/DefinitionXMLPathArray"
+        },
+        "attribute": {
+          "$ref": "#/definitions/DefinitionXmlAttribute"
+        },
+        "wordType": {
+          "$ref": "#/definitions/DefinitionWordType"
+        },
+        "type": {
+          "$ref": "#/definitions/DefinitionXmlTargetType"
+        }
+      },
+      "dependencies": {
+        "type": {
+          "$ref": "#/definitions/DefinitionDependencyType"
+        }
+      }
+    },
+    "ValueRaw": {
+      "title": "",
+      "description": "",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/DefinitionID"
+        },
+        "regex": {
+          "$ref": "#/definitions/DefinitionRegex"
+        }
+      },
+      "dependencies": {
+        "type": {
+          "$ref": "#/definitions/DefinitionDependencyType"
+        }
+      }
+    },
+    "DefinitionDependencyType": {
+      "oneOf": [
+        {
+          "properties": {
+            "type": {
+              "const": "URL"
+            },
+            "forceURLFormat": {
+              "$ref": "#/definitions/DefinitionForceURLFormat"
+            }
+          }
+        }
+      ]
+    },
+    "DefinitionJSONPathArray": {
+      "description": "A list of JSONPath strings to identify the element for translation",
+      "title": "JSON Paths",
       "type": "array",
       "uniqueItems": true,
       "default": [],
@@ -91,64 +247,138 @@
         "type": "string"
       }
     },
-    "WordType": {
-      "title": "WordType",
-      "description": "A Weglot Word Type",
+    "DefinitionXMLPathArray": {
+      "description": "A list of XML path (xpath) strings to identify the element(s) for translation. For more info see: w3schools.com/xml/xpath_syntax.asp",
+      "title": "XML paths",
+      "label": "More stuff",
+      "type": "array",
+      "uniqueItems": true,
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
+    "DefinitionWordType": {
+      "title": "Target word type",
+      "description": "If the target is a simple word: What kind of word is it?",
       "type": "integer",
       "oneOf": [
-        { "const": 1, "title": "1 - General text (used most of the time)" },
+        {
+          "const": 1,
+          "title": "1: General text (used most of the time)"
+        },
         {
           "const": 2,
-          "title": "2 - The value of an input tag'svalueattribute"
+          "title": "2: The value of an input tag's value attribute"
         },
         {
           "const": 3,
-          "title": "3 - The value of an input tag's placeholderattribute"
+          "title": "3: The value of an input tag's placeholder attribute"
         },
         {
           "const": 4,
-          "title": "4 - The value of a meta tags' content attribute"
+          "title": "4: The value of a meta tags' content attribute"
         },
-        { "const": 5, "title": "5 - The src link to a page used in an iframe" },
-        { "const": 6, "title": "6 - The srcvalue of an imgtag" },
-        { "const": 7, "title": "7 - The alt value of an imgtag" },
-        { "const": 8, "title": "8 - A URL pointing to a PDF document" },
-        { "const": 9, "title": "9 - The main resource title" },
-        { "const": 10, "title": "10 - An external URL" }
+        {
+          "const": 5,
+          "title": "5: The src link to a page used in an iframe"
+        },
+        {
+          "const": 6,
+          "title": "6: The srcvalue of an imgtag"
+        },
+        {
+          "const": 7,
+          "title": "7: The alt value of an imgtag"
+        },
+        {
+          "const": 8,
+          "title": "8: A URL pointing to a PDF document"
+        },
+        {
+          "const": 9,
+          "title": "9: The main resource title"
+        },
+        {
+          "const": 10,
+          "title": "10: An external URL"
+        }
       ]
     },
-    "ParserType": {
-      "title": "ParserType",
-      "description": "A Weglot available Parser Type",
+    "DefinitionTargetType": {
+      "title": "Target parsing type",
+      "description": "If the target is itself a more complex resource, how should it be parsed for translation?",
       "type": "string",
       "oneOf": [
-        { "const": "HTML", "title": "HTML parser" },
-        { "const": "JSON", "title": "JSON parser" },
-        { "const": "XML", "title": "XML parser" }
+        {
+          "const": "HTML",
+          "title": "Like a HTML resource"
+        },
+        {
+          "const": "JSON",
+          "title": "Like a JSON resource"
+        },
+        {
+          "const": "XML",
+          "title": "Like an XML resource"
+        },
+        {
+          "const": "URL",
+          "title": "It's a URL"
+        }
       ]
     },
-    "TargetType": {
-      "title": "TargetType",
-      "description": "A Weglot available Parser Type",
+    "DefinitionXmlTargetType": {
+      "title": "Target parsing type",
+      "description": "If the target is itself a more complex resource, how should it be parsed for translation?",
       "type": "string",
       "oneOf": [
-        { "const": "HTML", "title": "HTML parser" },
-        { "const": "JSON", "title": "JSON parser" },
-        { "const": "XML", "title": "XML parser" },
-        { "const": "URL", "title": "URL parser" },
-        { "const": "RAW", "title": "RAW parser" }
+        {
+          "const": "URL",
+          "title": "It's a URL"
+        }
       ]
     },
-    "ForceURLFormat": {
-      "title": "ForceURLFormat",
-      "description": "The format of the URL for the URL parser",
+    "DefinitionForceURLFormat": {
+      "title": "Output URL format",
+      "description": "If the target is a URL, how do you want it to be handled?",
       "type": "string",
-      "default": null,
       "oneOf": [
-        { "const": "proxy", "title": "Proxy" },
-        { "const": "shopifyProxy", "title": "Shopify proxy" },
-        { "const": "siteSettings", "title": "Site settings" }
+        {
+          "const": "siteSettings",
+          "title": "Like any other URL for this site"
+        },
+        {
+          "const": "proxy",
+          "title": "Proxify it (proxy.weglot.com)"
+        },
+        {
+          "const": "shopifyProxy",
+          "title": "(Legacy) Use the Shopify proxy"
+        }
       ]
+    },
+    "DefinitionID": {
+      "title": "Definition ID",
+      "description": "A unique identifier for this translation rule. (Only required if you want to refer to it in another rule later.)",
+      "type": "string"
+    },
+    "DefinitionSelector": {
+      "title": "CSS selector",
+      "type": "string"
+    },
+    "DefinitionHtmlAttribute": {
+      "title": "HTML tag attribute name",
+      "type": "string"
+    },
+    "DefinitionXmlAttribute": {
+      "title": "XML tag attribute name",
+      "type": "string"
+    },
+    "DefinitionRegex": {
+      "title": "Match and translate a regular expression",
+      "description": "Note: You can use named capturing groups in your Regex to force how the target is translated, e.g., (?<json>) or (?<wordType_1>). This supersedes “Target word type” and “Target parsing type” fields below, which are ignored when a Regex is provided.",
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
* Rewording to make the RulesBuilder process simpler.
* Add conditional schemas to avoid confusing additional options that aren't appropriate for the given resource: E.g., JSONPaths property on a HTML Resource.