### PR TITLE
Add referer language override settings (#96)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@weglot/technology-rules",
-  "version": "3.35.1",
+  "version": "3.36.0",
   "main": "index.js",
   "repository": "git@github.com:weglot/technology-rules.git",
   "author": "Weglot <support@weglot.com>",

--- a/rules/origins/akamai.json
+++ b/rules/origins/akamai.json
@@ -5,10 +5,10 @@
     {
       "condition": [
         {
-          "type": "TRANSLATION_URL_MATCH",
+          "type": "TRANSLATION_HOST_MATCH",
           "payload": {
             "type": "MATCH_REGEX",
-            "value": "https:\\/\\/([^\\/]+\\.weglot\\.(io|st)).*"
+            "value": "([^\\/]+\\.weglot\\.(io|st)).*"
           }
         }
       ],

--- a/rules/origins/referer-language.json
+++ b/rules/origins/referer-language.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "../../schemas/origins.schema.json",
+    "title": "Get translation language from referer from on original-language incoming requests",
+    "origins": [
+        {
+            "condition": [
+                {
+                    "type": "REQUEST_HEADER_MATCH",
+                    "payload": {
+                        "type": "IS_EXACTLY",
+                        "name": "X-Requested-With",
+                        "value": "XMLHttpRequest"
+                    }
+                }
+            ],
+            "value": [
+                {
+                    "language": {
+                        "useReferer": true
+                    }
+                }
+            ]
+        },
+        {
+            "condition": [
+                    {
+                      "type": "TECHNOLOGY_ID",
+                      "payload": 6
+                    },
+                    {
+                        "type": "REQUEST_HEADER_MATCH",
+                        "payload": {
+                            "name": "X-Wix-Brand",
+                            "type": "START_WITH",
+                            "value": ""
+                        }
+                    }
+            ],
+            "value": [
+                {
+                    "language": {
+                        "useReferer": true
+                    }
+                }
+            ]
+        },
+        {
+            "condition": [
+                    {
+                      "type": "TECHNOLOGY_ID",
+                      "payload": 2
+                    },
+                    {
+                        "type": "TRANSLATION_PATH_MATCH",
+                        "payload": {
+                            "type": "MATCH_REGEX",
+                            "value": "^/localization$"
+                        }
+                    }
+            ],
+            "value": [
+                {
+                    "language": {
+                        "useReferer": true
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/rules/origins/webflow.json
+++ b/rules/origins/webflow.json
@@ -17,10 +17,10 @@
           "payload": "cloudflare"
         },
         {
-          "type": "TRANSLATION_URL_MATCH",
+          "type": "TRANSLATION_HOST_MATCH",
           "payload": {
             "type": "MATCH_REGEX",
-            "value": "https:\\/\\/([^\\/]+\\.weglot\\.(io|st)).*"
+            "value": "([^\\/]+\\.weglot\\.(io|st)).*"
           }
         }
       ],

--- a/rules/technologies/shopify.json
+++ b/rules/technologies/shopify.json
@@ -3,7 +3,7 @@
   "title": "Shopify",
   "condition": [
     {
-      "type": "HEADER_MATCH",
+      "type": "RESPONSE_HEADER_MATCH",
       "payload": {
         "name": "x-shopify-stage",
         "type": "START_WITH",

--- a/rules/technologies/squarespace.json
+++ b/rules/technologies/squarespace.json
@@ -3,7 +3,7 @@
   "title": "Squarespace",
   "condition": [
     {
-      "type": "HEADER_MATCH",
+      "type": "RESPONSE_HEADER_MATCH",
       "payload": {
         "name": "x-via",
         "type": "MATCH_REGEX",
@@ -11,7 +11,7 @@
       }
     },
     {
-      "type": "HEADER_MATCH",
+      "type": "RESPONSE_HEADER_MATCH",
       "payload": {
         "name": "x-contextid",
         "type": "MATCH_REGEX",

--- a/rules/technologies/wix.json
+++ b/rules/technologies/wix.json
@@ -4,7 +4,7 @@
   "technology_id": 6,
   "condition": [
     {
-      "type": "HEADER_MATCH",
+      "type": "RESPONSE_HEADER_MATCH",
       "payload": {
         "name": "x-wix-request-id",
         "type": "START_WITH",

--- a/schemas/condition.schema.json
+++ b/schemas/condition.schema.json
@@ -31,27 +31,39 @@
             },
             {
               "const": "HOST_MATCH",
-              "title": "URL host match"
+              "title": "Match the (original-language) URL hostname of the page being translated"
             },
             {
               "const": "PATH_MATCH",
-              "title": "URL path match"
+              "title": "Match the (original-language) URL path (excluding search, ID) of the page being translated"
             },
             {
               "const": "URI_MATCH",
-              "title": "Original URL match"
+              "title": "Full string match on the (original-language) URL string of the page being translated"
             },
             {
               "const": "TRANSLATION_URL_MATCH",
-              "title": "Translation host match"
+              "title": "Full string match on the URL string of the page being translated"
+            },
+            {
+              "const": "TRANSLATION_HOST_MATCH",
+              "title": "Match the URL hostname of the page being translated"
+            },
+            {
+              "const": "TRANSLATION_PATH_MATCH",
+              "title": "Match the URL pathname (not counting query, hash) of the page being translated"
             },
             {
               "const": "TECHNOLOGY_ID",
               "title": "Website CMS technology"
             },
             {
-              "const": "HEADER_MATCH",
-              "title": "Match incoming header"
+              "const": "RESPONSE_HEADER_MATCH",
+              "title": "Match header in the response from the origin website"
+            },
+            {
+              "const": "REQUEST_HEADER_MATCH",
+              "title": "Match header in the request sent to the origin website"
             },
             {
               "const": "XML_ATTRIBUTE_VALUE",
@@ -121,6 +133,28 @@
             {
               "properties": {
                 "type": {
+                  "const": "TRANSLATION_HOST_MATCH"
+                },
+                "payload": {
+                  "description": "The translation URL hostname of the resource we want to translate needs to fulfill a criteria",
+                  "$ref": "#/defs/StringMatch"
+                }
+              }
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "TRANSLATION_PATH_MATCH"
+                },
+                "payload": {
+                  "description": "Match the path (excluding search, ID) of the page being translated",
+                  "$ref": "#/defs/StringMatch"
+                }
+              }
+            },
+            {
+              "properties": {
+                "type": {
                   "const": "TRANSLATION_URL_MATCH"
                 },
                 "payload": {
@@ -154,10 +188,21 @@
             {
               "properties": {
                 "type": {
-                  "const": "HEADER_MATCH"
+                  "const": "RESPONSE_HEADER_MATCH"
                 },
                 "payload": {
                   "description": "Detect using the incoming headers from the source",
+                  "$ref": "#/defs/StringMatch"
+                }
+              }
+            },
+            {
+              "properties": {
+                "type": {
+                  "const": "REQUEST_HEADER_MATCH"
+                },
+                "payload": {
+                  "description": "Detect using the headers sent to the source from the client",
                   "$ref": "#/defs/StringMatch"
                 }
               }

--- a/schemas/origins.schema.json
+++ b/schemas/origins.schema.json
@@ -72,6 +72,18 @@
             "additionalProperties": true,
             "description": "Headers to add or to override on the origin request."
         },
+        "Language": {
+            "title": "Override page language",
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Instructions for how to override the translation language on incoming original-language (subdirectory) requests.",
+            "properties": {
+                "useReferer": {
+                    "title": "Use the referer header's language to determine the language",
+                    "type": "boolean"
+                }
+            }
+        },
         "Cookies": {
             "title": "Override cookie",
             "type": "array",
@@ -93,6 +105,9 @@
                 },
                 "redirect": {
                     "$ref": "#/defs/Redirect"
+                },
+                "language": {
+                    "$ref": "#/defs/Language"
                 },
                 "protocol": {
                     "title": "Override the protocol used to fetch the origin.",


### PR DESCRIPTION
Note: This includes a renaming `HEADER_MATCH` => `RESPONSE_HEADER_MATCH` ; have done a search in the DB custom settings and there are no projects currently using this condition.

Related to:
https://github.com/weglot/connect-edge/pull/1861