### PR TITLE
Add graph api custom def (#98)

### DIFF
--- a/rules/translations/ld-json.json
+++ b/rules/translations/ld-json.json
@@ -1,4 +1,4 @@
-{ 
+{
   "translations": [
     {
       "type": "HTML",
@@ -21,9 +21,39 @@
       ],
       "value": [
         {
-          "paths": ["$.url", "$[*]['url']", "$.offers[*].url", "$.itemListElement[*].item['@id']", "$.offers[*].itemOffered.url"],
+          "paths": [
+            "$.url",
+            "$[*]['url']",
+            "$.offers[*].url",
+            "$.itemListElement[*].item['@id']",
+            "$.offers[*].itemOffered.url"
+          ],
           "type": "URL",
           "forceURLFormat": "siteSettings"
+        },
+        {
+          "paths": [
+            "$.[?(@root['@type'] == 'BreadcrumbList' && @root['@context'].match(/schema.org/i))].name",
+            "$[?(@root['@type'] == 'Product' && @root['@context'].match(/schema.org/i))]^.name",
+            "$[?(@root['@type'] == 'NewsArticle' && @root['@context'].match(/schema.org/i))]^.name",
+            "$[?(@root['@type'] == 'NewsArticle' && @root['@context'].match(/schema.org/i))]^.headline",
+            "$[?(@root['@type'] == 'Article' && @root['@context'].match(/schema.org/i))]^.name",
+            "$[?(@root['@type'] == 'Article' && @root['@context'].match(/schema.org/i))]^.headline",
+            "$[?(@root['@type'] == 'BlogPosting' && @root['@context'].match(/schema.org/i))]^.name",
+            "$[?(@root['@type'] == 'BlogPosting' && @root['@context'].match(/schema.org/i))]^.headline"
+          ]
+        },
+        {
+          "paths": [
+            "$[?(@root['@type'] == 'Product' && @root['@context'].match(/schema.org/i))]^.description",
+            "$[?(@root['@type'] == 'NewsArticle' && @root['@context'].match(/schema.org/i))]^.description",
+            "$[?(@root['@type'] == 'Article' && @root['@context'].match(/schema.org/i))]^.description",
+            "$[?(@root['@type'] == 'BlogPosting' && @root['@context'].match(/schema.org/i))]^.description"
+          ],
+          "type": "HTML",
+          "transforms": {
+            "name": "html"
+          }
         }
       ]
     }


### PR DESCRIPTION
A prendre avec des pincettes car pourrait drastiquement augmenter le nombre de mots de tous les projets utilisants graphapi.

Je pense qu'on devrait au moins commencer avec les type "Product" car on a beaucoup de Shopify et je crois que tous les produits on un ld+json graph par défaut. 

Exemple avec le shop de Vitality. On est en anglais mais le graphapi reste en français :
<img width="945" alt="image" src="https://github.com/user-attachments/assets/ca2a3dd8-3f99-4e58-bb9d-84c3baebc042">
